### PR TITLE
Feature/webserver returns algo results as json

### DIFF
--- a/cara/apps/calculator/__init__.py
+++ b/cara/apps/calculator/__init__.py
@@ -22,7 +22,7 @@ import tornado.log
 
 from . import markdown_tools
 from . import model_generator
-from .report_generator import ReportGenerator
+from .report_generator import ReportGenerator, calculate_report_data
 from .user import AuthenticatedUser, AnonymousUser
 
 
@@ -129,6 +129,44 @@ class ConcentrationModel(BaseRequestHandler):
         self.finish(report)
 
 
+class ConcentrationModelJsonResponse(BaseRequestHandler):
+    def check_xsrf_cookie(self):
+        """
+        This request handler implements a stateless API that returns report data in JSON format.
+        Thus, XSRF cookies are disabled by overriding base class implementation of this method with a pass statement.
+        """
+        pass
+
+    async def post(self):
+        """
+        Expects algorithm input in HTTP POST request body in JSON format.
+        Returns report data (algorithm output) in HTTP POST response body in JSON format.
+        """
+        requested_model_config = json.loads(self.request.body)
+        if self.settings.get("debug", False):
+            from pprint import pprint
+            pprint(requested_model_config)
+
+        try:
+            form = model_generator.FormData.from_dict(requested_model_config)
+        except Exception as err:
+            if self.settings.get("debug", False):
+                import traceback
+                print(traceback.format_exc())
+            response_json = {'code': 400, 'error': f'Your request was invalid {html.escape(str(err))}'}
+            self.set_status(400)
+            await self.finish(json.dumps(response_json))
+            return
+
+        executor = loky.get_reusable_executor(
+            max_workers=self.settings['handler_worker_pool_size'],
+            timeout=300,
+        )
+        report_data_task = executor.submit(calculate_report_data, form.build_model())
+        report_data: dict = await asyncio.wrap_future(report_data_task)
+        await self.finish(report_data)
+
+
 class StaticModel(BaseRequestHandler):
     async def get(self):
         form = model_generator.FormData.from_dict(model_generator.baseline_raw_form_data())
@@ -222,6 +260,7 @@ def make_app(
         (r'/static/(.*)', StaticFileHandler, {'path': static_dir}),
         (calculator_prefix + r'/?', CalculatorForm),
         (calculator_prefix + r'/report', ConcentrationModel),
+        (calculator_prefix + r'/report-json', ConcentrationModelJsonResponse),
         (calculator_prefix + r'/baseline-model/result', StaticModel),
         (calculator_prefix + r'/user-guide', ReadmeHandler),
         (calculator_prefix + r'/static/(.*)', StaticFileHandler, {'path': calculator_static_dir}),

--- a/cara/apps/calculator/model_generator.py
+++ b/cara/apps/calculator/model_generator.py
@@ -642,7 +642,7 @@ def build_expiration(expiration_definition) -> models._ExpirationBase:
         return expiration_distribution(tuple(BLO_factors))
 
 
-def baseline_raw_form_data():
+def baseline_raw_form_data() -> typing.Dict[str, typing.Union[str, float]]:
     # Note: This isn't a special "baseline". It can be updated as required.
     return {
         'activity_type': 'office',

--- a/cara/apps/calculator/report_generator.py
+++ b/cara/apps/calculator/report_generator.py
@@ -96,7 +96,7 @@ def interesting_times(model: models.ExposureModel, approx_n_pts=100) -> typing.L
     return nice_times
 
 
-def calculate_report_data(model: models.ExposureModel):
+def calculate_report_data(model: models.ExposureModel) -> typing.Dict[str, typing.Any]:
     times = interesting_times(model)
 
     concentrations = [

--- a/cara/tests/apps/calculator/test_report_json.py
+++ b/cara/tests/apps/calculator/test_report_json.py
@@ -1,0 +1,31 @@
+import json
+
+import tornado.testing
+
+import cara.apps.calculator
+from cara.apps.calculator import model_generator
+
+_TIMEOUT = 40.
+
+
+class TestCalculatorJsonResponse(tornado.testing.AsyncHTTPTestCase):
+    def setUp(self):
+        super().setUp()
+        self.http_client.defaults['request_timeout'] = _TIMEOUT
+
+    def get_app(self):
+        return cara.apps.calculator.make_app()
+
+    @tornado.testing.gen_test(timeout=_TIMEOUT)
+    def test_json_response(self):
+        response = yield self.http_client.fetch(
+            request=self.get_url("/calculator/report-json"),
+            method="POST",
+            headers={'content-type': 'application/json'},
+            body=json.dumps(model_generator.baseline_raw_form_data())
+        )
+        self.assertEqual(response.code, 200)
+
+        data = json.loads(response.body)
+        self.assertIsInstance(data['prob_inf'], float)
+        self.assertIsInstance(data['expected_new_cases'], float)


### PR DESCRIPTION
# Additional HTTP POST Handler (JSON Response)

Added additional HTTP POST handler to Tornado webserver that sends algorithm results as JSON in HTTP response.

- Gets algo input from HTTP POST request body (JSON)
- Returns 'report_data' in HTTP response body (JSON)

Note that for using this additional HTTP POST, either XSRF cookies must be turned off when starting Tornado or XSRF cookie must be obtained and sent in HTTP POST request header. XSRF cookie can be obtained by sending an HTTP GET request to e.g. '/calculator'.

Also added test that checks for presence of key 'prob_inf' in HTTP POST response body.