### PR TITLE
chore: introduce pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-executables-have-shebangs
+      # check toml files
+      - id: check-toml
+      # check yaml files
+      - id: check-yaml
+      # fixing empty or blank of end file
+      - id: end-of-file-fixer
+        types: [python]
+      # check trailing whitespace on file
+      - id: trailing-whitespace
+      # sort the entries of package on requirements.txt
+      - id: requirements-txt-fixer
+
+  # ruff formatter and linter
+  # replace black and flake8
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.3
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  # mirror of prettier
+  # beautify of toml and yaml files
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v4.0.0-alpha.8"
+    hooks:
+      - id: prettier
+        types_or: [toml, yaml]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+line-length = 88
+
+# ignore specific error from lint with ruff
+[lint]
+ignore = ["F541", "F841", "E711", "E721", "F541", "E741", "F401", "F403", "E712", "E731", "F811"]
+
+
+[format]
+# according PEP8 python, double quotes for strings.
+quote-style = "double"


### PR DESCRIPTION
adding pre-commit configuration for better development and maintain with introduce some lib including
- ruff ( formatter and linter )
	replace for black formatter and flake8 linter, cause ruff are configuraable and more quick for formatting and linting on python projects
- builtin pre-commit configuration
	- check-yaml
	- end-of-file-fixer
	- trailing whitespace
	- requirements txt fixer

- ruff configuration
	configuration for ruff formatter and linter, which can dynamically config for specific project

reference:
	- ruff: https://docs.astral.sh/ruff/
	- pre-commit: https://pre-commit.com/

note: can configure with other development lib, and can use builtin or 3rd party lib

testimonial on other project ( [geemap](https://github.com/gee-community/geemap)

![image](https://github.com/CERN/CAiMIRA/assets/40540262/1e23664d-d5ad-419f-9e14-b21892b2c509)
