### PR TITLE
test: stabilize flaky parametrization in test_known_quantities

### DIFF
--- a/caimira/tests/test_known_quantities.py
+++ b/caimira/tests/test_known_quantities.py
@@ -370,7 +370,7 @@ def test_concentrations_hourly_dep_adding_artificial_transitions(data_registry, 
 @pytest.mark.parametrize(
     "time",
     (
-        [float(t) for t in np.random.random_sample(10) * 24.]  # type: ignore
+        [float(t) for t in np.random.RandomState(42).random_sample(10) * 24.]  # type: ignore
         + [float(t) for t in np.arange(0, 24.5, 0.5)]
     ),
 )


### PR DESCRIPTION
## Summary
Fixes #8

## Problem
The parametrization for `test_concentrations_refine_times` in `test_known_quantities.py` relies on `np.random.random_sample(10)`. Because this is evaluated dynamically at test discovery time, the test times vary across executions. Without a fixed seed, this behavior contributes to intermittent test flakiness and complicates failure reproduction across parallel test runners.

## Solution
Replaced the global `np.random.random_sample` call with a localized, deterministic `np.random.RandomState(42).random_sample()` generator. This ensures the parametrization evaluates to the exact same pseudo-random sequence during every run without altering global random seeds elsewhere in the application.

## Changes
- `caimira/tests/test_known_quantities.py`: applied deterministic random state to `test_concentrations_refine_times`.
